### PR TITLE
Add tests for nearly all laws

### DIFF
--- a/hedgehog-classes.cabal
+++ b/hedgehog-classes.cabal
@@ -164,14 +164,11 @@ test-suite spec
 --                       Spec.Ix
                        Spec.Json
                        Spec.Monad
-                       Spec.MonadIO
-                       Spec.MonadPlus
-                       Spec.MonadZip
                        Spec.Monoid
                        Spec.Ord
                        Spec.Semigroup
+                       Spec.Semiring
                        Spec.Show
-                       Spec.ShowRead
                        Spec.Storable
                        Spec.Traversable
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -21,14 +21,11 @@ import Spec.Integral
 --import Spec.Ix
 import Spec.Json
 import Spec.Monad
-import Spec.MonadIO
-import Spec.MonadPlus
-import Spec.MonadZip
 import Spec.Monoid
 import Spec.Ord
 import Spec.Semigroup
+import Spec.Semiring
 import Spec.Show
-import Spec.ShowRead
 import Spec.Storable
 import Spec.Traversable
 
@@ -53,6 +50,9 @@ allNullaryLaws = testBits
   ++ testExponentialSemigroup
   ++ testIdempotentSemigroup
   ++ testRectangularBandSemigroup
+  ++ testSemiring
+  ++ testRing
+  ++ testStar
   ++ testShow
   ++ testShowRead
   ++ testStorable

--- a/test/Spec/Bifoldable.hs
+++ b/test/Spec/Bifoldable.hs
@@ -15,18 +15,20 @@ testBifoldable =
 
 testBifoldableFunctor :: [(String, [Laws])]
 testBifoldableFunctor =
-  [ ("Either", lawsEither)
-  , ("Const", lawsConst)
+  [ ("Either", functorLawsEither)
+  , ("Const", functorLawsConst)
   ]
 
-lawsEither :: [Laws]
-lawsEither = [bifoldableLaws either]
-
-lawsConst :: [Laws]
+lawsConst, functorLawsConst :: [Laws]
 lawsConst = [bifoldableLaws const]
+functorLawsConst = [bifoldableFunctorLaws const]
 
 const :: MonadGen m => m a -> m b -> m (Const a b)
 const genA _genB = fmap Const genA
+
+lawsEither, functorLawsEither :: [Laws]
+lawsEither = [bifoldableLaws either]
+functorLawsEither = [bifoldableFunctorLaws either]
 
 either :: MonadGen m => m e -> m a -> m (Either e a)
 either genE genA =

--- a/test/Spec/Enum.hs
+++ b/test/Spec/Enum.hs
@@ -3,11 +3,17 @@ module Spec.Enum (testEnum, testBoundedEnum) where
 import Hedgehog
 import Hedgehog.Classes
 
+import Data.Int (Int64)
+import Data.Word (Word64)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
+import Numeric.Natural (Natural)
 
 testEnum :: [(String, [Laws])]
-testEnum = []
+testEnum =
+  [ ("Integer", listInteger)
+  , ("Natural", listNatural)
+  ]
 
 testBoundedEnum :: [(String, [Laws])]
 testBoundedEnum =
@@ -58,3 +64,12 @@ listWord8 = [boundedEnumLaws (ranged Gen.word8)]
 listWord16 = [boundedEnumLaws (ranged Gen.word16)]
 listWord32 = [boundedEnumLaws (ranged Gen.word32)]
 listWord64 = [boundedEnumLaws (ranged Gen.word64)]
+
+listInteger, listNatural :: [Laws]
+listInteger = [enumLaws (Gen.integral $ Range.constantFrom
+    (0 :: Integer)
+    (2 * fromIntegral (minBound :: Int64))
+    (2 * fromIntegral (maxBound :: Int64)))]
+listNatural = [enumLaws (Gen.integral $ Range.constant
+    (0 :: Natural)
+    (2 * fromIntegral (maxBound :: Word64)))]

--- a/test/Spec/Monad.hs
+++ b/test/Spec/Monad.hs
@@ -1,4 +1,13 @@
-module Spec.Monad (testMonad) where
+module Spec.Monad
+  ( testMonad
+  , testMonadIO
+  , testMonadPlus
+  , testMonadZip
+  ) where
+
+import Control.Applicative (Alternative(..))
+import Control.Monad (MonadPlus(..))
+import Control.Monad.IO.Class (MonadIO(..))
 
 import Data.Functor.Compose (Compose(..))
 import Data.Functor.Identity (Identity(..))
@@ -9,20 +18,48 @@ import Hedgehog.Classes
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
+import System.IO.Unsafe (unsafePerformIO)
+
 import Prelude hiding (either)
 
 testMonad :: [(String, [Laws])]
 testMonad =
   [ ("[]", lawsList)
-  , ("Maybe", lawsMaybe)
   , ("Either e", lawsEither)
+  , ("Identity", lawsIdentity)
+  --, ("IO", lawsIO)
+  , ("Maybe", lawsMaybe)
   ]
 
-lawsList :: [Laws]
-lawsList = [monadLaws (Gen.list (Range.linear 0 6))]
+{-
+testMonadFix :: [(String, [Laws])]
+testMonadFix =
+  [ ("[]", fixLawsList)
+  , ("Either e", fixLawsEither)
+  , ("Identity", fixLawsIdentity)
+  , ("IO", fixLawsIO)
+  , ("Maybe", fixLawsMaybe)
+  ]
+-}
 
-lawsMaybe :: [Laws]
-lawsMaybe = [monadLaws Gen.maybe]
+testMonadIO :: [(String, [Laws])]
+testMonadIO =
+  [ ("IO", ioLawsIO)
+  ]
+
+testMonadPlus :: [(String, [Laws])]
+testMonadPlus =
+  [ ("[]", plusLawsList)
+  --, ("IO", plusLawsIO)
+  , ("Maybe", plusLawsMaybe)
+  ]
+
+testMonadZip :: [(String, [Laws])]
+testMonadZip =
+  [ ("[]", zipLawsList)
+  , ("Identity", zipLawsIdentity)
+  , ("Maybe", zipLawsMaybe)
+  ]
 
 lawsEither :: [Laws]
 lawsEither = [monadLaws eitherInteger]
@@ -37,3 +74,56 @@ either genE genA =
         (2, Left <$> genE)
       , (1 + fromIntegral n, Right <$> genA)
       ]
+
+lawsIdentity, zipLawsIdentity :: [Laws]
+lawsIdentity = [monadLaws identity]
+zipLawsIdentity = [monadZipLaws identity]
+
+identity :: MonadGen m => m a -> m (Identity a)
+identity = fmap Identity
+
+lawsList, plusLawsList, zipLawsList :: [Laws]
+lawsList = [monadLaws list]
+plusLawsList = [monadPlusLaws list]
+zipLawsList = [monadZipLaws list]
+
+list :: MonadGen m => m a -> m [a]
+list = Gen.list $ Range.linear 0 6
+
+lawsMaybe, plusLawsMaybe, zipLawsMaybe :: [Laws]
+lawsMaybe = [monadLaws Gen.maybe]
+plusLawsMaybe = [monadPlusLaws Gen.maybe]
+zipLawsMaybe = [monadZipLaws Gen.maybe]
+
+lawsIO, ioLawsIO, plusLawsIO :: [Laws]
+lawsIO = [monadLaws io]
+ioLawsIO = [monadIOLaws io]
+plusLawsIO = [monadPlusLaws io]
+
+newtype TestIO a = TestIO (IO a)
+-- | Unsafe!
+instance Eq a => Eq (TestIO a) where
+  TestIO a == TestIO b = unsafePerformIO $ do
+    a' <- a
+    b' <- b
+    return $ a' == b'
+-- | Unsafe!
+instance Show a => Show (TestIO a) where
+  showsPrec d (TestIO a) = unsafePerformIO $ fmap (showsPrec d) a
+instance Functor TestIO where
+  fmap f (TestIO a) = TestIO $ fmap f a
+instance Applicative TestIO where
+  pure = TestIO . pure
+  TestIO a <*> TestIO b = TestIO $ a <*> b
+instance Alternative TestIO where
+  empty = TestIO empty
+  TestIO a <|> TestIO b = TestIO $ a <|> b
+-- | Unsafe!  And also doesn't seem to work...
+instance Monad TestIO where
+  TestIO a >>= f = f $ unsafePerformIO a
+instance MonadIO TestIO where
+  liftIO = TestIO
+instance MonadPlus TestIO
+
+io :: MonadGen m => m a -> m (TestIO a)
+io = fmap return

--- a/test/Spec/MonadIO.hs
+++ b/test/Spec/MonadIO.hs
@@ -1,6 +1,0 @@
-module Spec.MonadIO (testMonadIO) where
-
-import Hedgehog.Classes
-
-testMonadIO :: [(String, [Laws])]
-testMonadIO = []

--- a/test/Spec/MonadPlus.hs
+++ b/test/Spec/MonadPlus.hs
@@ -1,6 +1,0 @@
-module Spec.MonadPlus (testMonadPlus) where
-
-import Hedgehog.Classes
-
-testMonadPlus :: [(String, [Laws])]
-testMonadPlus = []

--- a/test/Spec/MonadZip.hs
+++ b/test/Spec/MonadZip.hs
@@ -1,6 +1,0 @@
-module Spec.MonadZip (testMonadZip) where
-
-import Hedgehog.Classes
-
-testMonadZip :: [(String, [Laws])]
-testMonadZip = []

--- a/test/Spec/Monoid.hs
+++ b/test/Spec/Monoid.hs
@@ -18,29 +18,37 @@ testMonoid =
 
 testCommutativeMonoid :: [(String, [Laws])]
 testCommutativeMonoid =
-  [ ("Sum Integer", lawsSum)
-  , ("Product Integer", lawsProduct)
-  , ("Maybe Integer", lawsMaybe)
+  [ ("Sum Integer", commutativeLawsSum)
+  , ("Product Integer", commutativeLawsProduct)
+  , ("Maybe Integer", commutativeLawsMaybe)
   ]
-
-lawsSum, lawsProduct, lawsMaybe, lawsAp :: [Laws]
-
-lawsSum = [monoidLaws genSum]
-lawsProduct = [monoidLaws genProduct]
-lawsMaybe = [monoidLaws genMaybe]
-lawsAp = [monoidLaws genAp]
 
 genInteger :: Gen Integer
 genInteger = Gen.integral (Range.linear (-3) 20)
 
+lawsSum, commutativeLawsSum :: [Laws]
+lawsSum = [monoidLaws genSum]
+commutativeLawsSum = [commutativeMonoidLaws genSum]
+
 genSum :: Gen (Sum Integer)
 genSum = fmap coerce genInteger
+
+lawsProduct, commutativeLawsProduct :: [Laws]
+lawsProduct = [monoidLaws genProduct]
+commutativeLawsProduct = [commutativeMonoidLaws genProduct]
 
 genProduct :: Gen (Product Integer)
 genProduct = fmap coerce genInteger
 
+lawsMaybe, commutativeLawsMaybe :: [Laws]
+lawsMaybe = [monoidLaws genMaybe]
+commutativeLawsMaybe = [commutativeMonoidLaws genMaybe]
+
 genMaybe :: Gen (Maybe (Sum Integer))
 genMaybe = Gen.maybe genSum
+
+lawsAp :: [Laws]
+lawsAp = [monoidLaws genAp]
 
 genAp :: Gen (Ap Maybe (Sum Integer))
 genAp = fmap coerce genMaybe

--- a/test/Spec/Semigroup.hs
+++ b/test/Spec/Semigroup.hs
@@ -9,27 +9,54 @@ module Spec.Semigroup
 import Hedgehog.Classes
 
 import Data.Monoid (Sum(..))
+import Data.Semigroup (Last(..))
 import Hedgehog (Gen)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 testSemigroup :: [(String, [Laws])]
-testSemigroup = [("Maybe", listMaybe)]
-
-listMaybe :: [Laws]
-listMaybe = map ($ genMaybe) [semigroupLaws, commutativeSemigroupLaws]
-
-genMaybe :: Gen (Maybe (Sum Int))
-genMaybe = Gen.maybe (fmap Sum $ Gen.int Range.constantBounded)
+testSemigroup =
+  [ ("Last", lawsLast)
+  , ("Maybe", lawsMaybe)
+  ]
 
 testCommutativeSemigroup :: [(String, [Laws])]
-testCommutativeSemigroup = []
+testCommutativeSemigroup =
+  [ ("Maybe", commutativeLawsMaybe)
+  ]
 
 testExponentialSemigroup :: [(String, [Laws])]
-testExponentialSemigroup = []
+testExponentialSemigroup =
+  [ ("Last", exponentialLawsLast)
+  , ("Maybe", exponentialLawsMaybe)
+  ]
 
 testIdempotentSemigroup :: [(String, [Laws])]
-testIdempotentSemigroup = []
+testIdempotentSemigroup =
+  [ ("Last", idempotentLawsLast)
+  ]
 
 testRectangularBandSemigroup :: [(String, [Laws])]
-testRectangularBandSemigroup = []
+testRectangularBandSemigroup =
+  [ ("Last", rectangularBandLawsLast)
+  ]
+
+genInteger :: Gen Integer
+genInteger = Gen.integral (Range.linear (-3) 20)
+
+lawsLast, exponentialLawsLast, idempotentLawsLast, rectangularBandLawsLast :: [Laws]
+lawsLast = [semigroupLaws genLast]
+exponentialLawsLast = [exponentialSemigroupLaws genLast]
+idempotentLawsLast = [idempotentSemigroupLaws genLast]
+rectangularBandLawsLast = [rectangularBandSemigroupLaws genLast]
+
+genLast :: Gen (Last Integer)
+genLast = Last <$> genInteger
+
+lawsMaybe, commutativeLawsMaybe, exponentialLawsMaybe :: [Laws]
+lawsMaybe = [semigroupLaws genMaybe]
+commutativeLawsMaybe = [commutativeSemigroupLaws genMaybe]
+exponentialLawsMaybe = [exponentialSemigroupLaws genMaybe]
+
+genMaybe :: Gen (Maybe (Sum Integer))
+genMaybe = Gen.maybe (Sum <$> genInteger)

--- a/test/Spec/Semiring.hs
+++ b/test/Spec/Semiring.hs
@@ -1,0 +1,79 @@
+module Spec.Semiring
+  ( testSemiring
+  , testRing
+  , testStar
+  ) where
+
+import Hedgehog.Classes
+
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+testSemiring :: [(String, [Laws])]
+testSemiring =
+  [ ("Bool", lawsBool)
+  , ("Int", lawsInt)
+  , ("Int8", lawsInt8)
+  , ("Int16", lawsInt16)
+  , ("Int32", lawsInt32)
+  , ("Int64", lawsInt64)
+  , ("Word", lawsWord)
+  , ("Word8", lawsWord8)
+  , ("Word16", lawsWord16)
+  , ("Word32", lawsWord32)
+  , ("Word64", lawsWord64)
+  ]
+
+testRing :: [(String, [Laws])]
+testRing =
+  [ ("Int", ringLawsInt)
+  , ("Int8", ringLawsInt8)
+  , ("Int16", ringLawsInt16)
+  , ("Int32", ringLawsInt32)
+  , ("Int64", ringLawsInt64)
+  , ("Word", ringLawsWord)
+  , ("Word8", ringLawsWord8)
+  , ("Word16", ringLawsWord16)
+  , ("Word32", ringLawsWord32)
+  , ("Word64", ringLawsWord64)
+  ]
+
+testStar :: [(String, [Laws])]
+testStar =
+  [ ("Bool", starLawsBool)
+  ]
+
+ranged :: (Bounded a, Num a) => (Range.Range a -> b) -> b
+ranged f = f Range.constantBounded
+
+lawsBool, starLawsBool :: [Laws]
+lawsBool = [semiringLaws Gen.bool]
+starLawsBool = [starLaws Gen.bool]
+
+lawsInt, lawsInt8, lawsInt16, lawsInt32, lawsInt64 :: [Laws]
+lawsInt = [semiringLaws (ranged Gen.int)]
+lawsInt8 = [semiringLaws (ranged Gen.int8)]
+lawsInt16 = [semiringLaws (ranged Gen.int16)]
+lawsInt32 = [semiringLaws (ranged Gen.int32)]
+lawsInt64 = [semiringLaws (ranged Gen.int64)]
+
+lawsWord, lawsWord8, lawsWord16, lawsWord32, lawsWord64 :: [Laws]
+lawsWord = [semiringLaws (ranged Gen.word)]
+lawsWord8 = [semiringLaws (ranged Gen.word8)]
+lawsWord16 = [semiringLaws (ranged Gen.word16)]
+lawsWord32 = [semiringLaws (ranged Gen.word32)]
+lawsWord64 = [semiringLaws (ranged Gen.word64)]
+
+ringLawsInt, ringLawsInt8, ringLawsInt16, ringLawsInt32, ringLawsInt64 :: [Laws]
+ringLawsInt = [ringLaws (ranged Gen.int)]
+ringLawsInt8 = [ringLaws (ranged Gen.int8)]
+ringLawsInt16 = [ringLaws (ranged Gen.int16)]
+ringLawsInt32 = [ringLaws (ranged Gen.int32)]
+ringLawsInt64 = [ringLaws (ranged Gen.int64)]
+
+ringLawsWord, ringLawsWord8, ringLawsWord16, ringLawsWord32, ringLawsWord64 :: [Laws]
+ringLawsWord = [ringLaws (ranged Gen.word)]
+ringLawsWord8 = [ringLaws (ranged Gen.word8)]
+ringLawsWord16 = [ringLaws (ranged Gen.word16)]
+ringLawsWord32 = [ringLaws (ranged Gen.word32)]
+ringLawsWord64 = [ringLaws (ranged Gen.word64)]

--- a/test/Spec/Show.hs
+++ b/test/Spec/Show.hs
@@ -1,6 +1,81 @@
-module Spec.Show (testShow) where
+module Spec.Show
+  ( testShow
+  , testShowRead
+  ) where
 
+import Hedgehog
 import Hedgehog.Classes
 
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
 testShow :: [(String, [Laws])]
-testShow = []
+testShow =
+  [ ("E", lawsE)
+  , ("Int", lawsInt)
+  , ("Int8", lawsInt8)
+  , ("Int16", lawsInt16)
+  , ("Int32", lawsInt32)
+  , ("Int64", lawsInt64)
+  , ("Word", lawsWord)
+  , ("Word8", lawsWord8)
+  , ("Word16", lawsWord16)
+  , ("Word32", lawsWord32)
+  , ("Word64", lawsWord64) 
+  ]
+
+testShowRead :: [(String, [Laws])]
+testShowRead =
+  [ ("E", readLawsE)
+  , ("Int", readLawsInt)
+  , ("Int8", readLawsInt8)
+  , ("Int16", readLawsInt16)
+  , ("Int32", readLawsInt32)
+  , ("Int64", readLawsInt64)
+  , ("Word", readLawsWord)
+  , ("Word8", readLawsWord8)
+  , ("Word16", readLawsWord16)
+  , ("Word32", readLawsWord32)
+  , ("Word64", readLawsWord64) 
+  ]
+
+lawsE, readLawsE :: [Laws]
+lawsE = [showLaws genE]
+readLawsE = [showReadLaws genE]
+
+data E = E1 | E2 | E3 | E4 | E5 | E6 | E7 | E8
+  deriving (Eq, Show, Read, Enum, Bounded)
+
+genE :: Gen E
+genE = Gen.enumBounded
+
+ranged :: (Bounded a, Num a) => (Range.Range a -> b) -> b
+ranged f = f (Range.constantBounded)
+
+lawsInt, lawsInt8, lawsInt16, lawsInt32, lawsInt64 :: [Laws]
+lawsInt = [showLaws (ranged Gen.int)]
+lawsInt8 = [showLaws (ranged Gen.int8)]
+lawsInt16 = [showLaws (ranged Gen.int16)]
+lawsInt32 = [showLaws (ranged Gen.int32)]
+lawsInt64 = [showLaws (ranged Gen.int64)]
+
+lawsWord, lawsWord8, lawsWord16, lawsWord32, lawsWord64 :: [Laws]
+lawsWord = [showLaws (ranged Gen.word)]
+lawsWord8 = [showLaws (ranged Gen.word8)]
+lawsWord16 = [showLaws (ranged Gen.word16)]
+lawsWord32 = [showLaws (ranged Gen.word32)]
+lawsWord64 = [showLaws (ranged Gen.word64)]
+
+readLawsInt, readLawsInt8, readLawsInt16, readLawsInt32, readLawsInt64 :: [Laws]
+readLawsInt = [showReadLaws (ranged Gen.int)]
+readLawsInt8 = [showReadLaws (ranged Gen.int8)]
+readLawsInt16 = [showReadLaws (ranged Gen.int16)]
+readLawsInt32 = [showReadLaws (ranged Gen.int32)]
+readLawsInt64 = [showReadLaws (ranged Gen.int64)]
+
+readLawsWord, readLawsWord8, readLawsWord16, readLawsWord32, readLawsWord64 :: [Laws]
+readLawsWord = [showReadLaws (ranged Gen.word)]
+readLawsWord8 = [showReadLaws (ranged Gen.word8)]
+readLawsWord16 = [showReadLaws (ranged Gen.word16)]
+readLawsWord32 = [showReadLaws (ranged Gen.word32)]
+readLawsWord64 = [showReadLaws (ranged Gen.word64)]

--- a/test/Spec/ShowRead.hs
+++ b/test/Spec/ShowRead.hs
@@ -1,6 +1,0 @@
-module Spec.ShowRead (testShowRead) where
-
-import Hedgehog.Classes
-
-testShowRead :: [(String, [Laws])]
-testShowRead = []

--- a/test/Spec/Storable.hs
+++ b/test/Spec/Storable.hs
@@ -2,5 +2,36 @@ module Spec.Storable (testStorable) where
 
 import Hedgehog.Classes
 
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
 testStorable :: [(String, [Laws])]
-testStorable = []
+testStorable =
+  [ ("Int", lawsInt)
+  , ("Int8", lawsInt8)
+  , ("Int16", lawsInt16)
+  , ("Int32", lawsInt32)
+  , ("Int64", lawsInt64)
+  , ("Word", lawsWord)
+  , ("Word8", lawsWord8)
+  , ("Word16", lawsWord16)
+  , ("Word32", lawsWord32)
+  , ("Word64", lawsWord64)
+  ]
+
+ranged :: (Bounded a, Num a) => (Range.Range a -> b) -> b
+ranged f = f (Range.constantBounded)
+
+lawsInt, lawsInt8, lawsInt16, lawsInt32, lawsInt64 :: [Laws]
+lawsInt = [storableLaws (ranged Gen.int)]
+lawsInt8 = [storableLaws (ranged Gen.int8)]
+lawsInt16 = [storableLaws (ranged Gen.int16)]
+lawsInt32 = [storableLaws (ranged Gen.int32)]
+lawsInt64 = [storableLaws (ranged Gen.int64)]
+
+lawsWord, lawsWord8, lawsWord16, lawsWord32, lawsWord64 :: [Laws]
+lawsWord = [storableLaws (ranged Gen.word)]
+lawsWord8 = [storableLaws (ranged Gen.word8)]
+lawsWord16 = [storableLaws (ranged Gen.word16)]
+lawsWord32 = [storableLaws (ranged Gen.word32)]
+lawsWord64 = [storableLaws (ranged Gen.word64)]

--- a/test/Spec/Traversable.hs
+++ b/test/Spec/Traversable.hs
@@ -2,5 +2,13 @@ module Spec.Traversable (testTraversable) where
 
 import Hedgehog.Classes
 
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
 testTraversable :: [(String, [Laws])]
-testTraversable = []
+testTraversable =
+  [ ("[]", lawsList)
+  ]
+
+lawsList :: [Laws]
+lawsList = [traversableLaws (Gen.list (Range.linear 0 6))]


### PR DESCRIPTION
After the issues with `Ord` and `Storable`, it seemed like a good idea to be sure there weren't any other bugs in the tests themselves, and that can't really be done with a half-null test suite.  Good news is, those seem to be the only problems!  At least, unless something's hiding in `Arrow` or `Category`...

I wound up splitting some of the laws lists (see, eg., `Semigroup.hs`) on the basis that the sublaws shouldn't be mashed into the overriding ones, leaving their top-level `test*Laws` empty, but it does seem like a bit of an unwieldy layout with the output being divided by both law category and instance type.  In my mind, the best would be to have a single group for `testShowLaws`, say, containing one list of `concat [lawsE, lawsInt*, lawsWord*]`, but as there's not any way to specify a prefix for the individual laws themselves, having a big block of identical "Commutative Monoid: passed" statements doesn't help anything.  Regardless, I see the `laws*` lists as being in this case more for if one of them needs testing with multiple generators in the future than for testing different sets of laws.