### PR TITLE
Move to hedgehogqa

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,23 +72,11 @@ Below is an example of an error message one might get from a failed test from `h
 
 ![alt text](imgs/badsemigroup.png "Here we can see a semigroup instance which is not associative")
 
-## Differences from similar libraries
-There are a number of libraries that have similar goals to `hedgehog-classes`, and I will discuss only those that wrap `hedgehog`, not `QuickCheck`.
+## Similar libraries
+There are a number of libraries that have similar goals to `hedgehog-classes`:
 
   - [hedgehog-checkers](https://github.com/bitemyapp/hedgehog-checkers):
-      - Incomplete
-      - Not actively developed
-      - Less typeclasses
-      - Hasn't been uploaded to hackage, even with a sufficient starting-point API
-      - API is slightly more complex
-      - Does not make an effort to provide custom error messages
-      - Currently the only thing `hedgehog-checkers` can do that this library cannot
-        is test properties of higher-kinded typeclass laws where the construction of
-        the type requires constraints on its type arguments (e.g. `Ord` for something
-        like `Data.Set.Set`)
-
   - [hedgehog-laws](https://github.com/qfpl/hedgehog-laws):
-      - All of the things that apply to `hedgehog-checkers`, but even more incomplete.
 
 ## Supported Typeclasses
 

--- a/hedgehog-classes.cabal
+++ b/hedgehog-classes.cabal
@@ -16,9 +16,9 @@ description:
   .
   This library is directly inspired by `quickcheck-classes`.
 homepage:
-  https://github.com/chessai/hedgehog-classes
+  https://github.com/hedgehogqa/haskell-hedgehog-classes
 bug-reports:
-  https://github.com/chessai/hedgehog-classes/issues
+  https://github.com/hedgehogqa/haskell-hedgehog-classes/issues
 license:
   BSD-3-Clause
 license-file:
@@ -42,7 +42,7 @@ source-repository head
   type:
     git
   location:
-    https://github.com/chessai/hedgehog-classes.git
+    https://github.com/hedgehogqa/haskell-hedgehog-classes.git
 
 flag aeson
   description:


### PR DESCRIPTION
As mentioned on Slack, it may help people discover it more easily! I think anyone using haskell-hedgehog at least ought to know about this repo and its capabilities.

I've discussed this with @jacobstanley, and ended up thinking about moving it as `haskell-hedgehog-classes` to sort next to the other haskell repo(s). The name remains the same of course.

The other thing we've discussed is to make the README a bit friendlier in the *similar libraries* section. If this repo is part of @hedgehogqa org, I guess it means it's doing its job correctly.

See PR below and let us know :nerd_face: :rocket: :heart_eyes: :confetti_ball: 